### PR TITLE
chore: remove unneeded checkout step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,6 @@ jobs:
     environment: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       # https://blog.oddbit.com/post/2020-09-25-building-multi-architecture-im/
       - name: Prepare
         id: prep


### PR DESCRIPTION
buildx does its own git checkout