### PR TITLE
fix: give release-please a pat

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,10 +3,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 name: release-please
 
 jobs:
@@ -15,5 +11,6 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: go
           package-name: github.com/mikesmitty/mdns-mesh


### PR DESCRIPTION
release-please requires a GitHub token to access the GitHub API. You configure this token via the token configuration option. You can use the built-in GITHUB_TOKEN secret, however, note that any resources created by release-please (release tag or release pull request) will not trigger future GitHub actions workflows.

From the [docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow):

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

This means that GitHub actions CI checks will not run on the release pull request and workflows normally triggered by release.created events will also not run. You will want to configure a GitHub actions secret with a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) if you want other workflows to run.

https://github.com/google-github-actions/release-please-action#github-credentials